### PR TITLE
Prefer delete-forward-char which respect delete-selection-mode

### DIFF
--- a/worf.el
+++ b/worf.el
@@ -824,7 +824,7 @@ _t_his
   (interactive "p")
   (if (and (looking-at "\\*") (looking-back "^\\**"))
       (org-cut-subtree)
-    (delete-char arg)))
+    (delete-forward-char arg)))
 
 (defun worf-copy-heading-id (arg)
   "Copy the id link of current heading to kill ring.


### PR DESCRIPTION
As per doc : 

The command `delete-forward-char` is preferable for interactive use, e.g.
because it respects values of `delete-active-region` and `overwrite-mode`.
