### PR TITLE
Press , to set priority.

### DIFF
--- a/worf.el
+++ b/worf.el
@@ -1416,6 +1416,7 @@ calling `self-insert-command'."
   (worf-define-key map "t" 'worf-todo)
   (worf-define-key map "u" 'undo)
   (worf-define-key map "R" 'worf-recenter-mode)
+  (worf-define-key map "," 'org-priority)
   ;; ——— digit argument ———————————————————————
   (mapc (lambda (x) (worf-define-key map (format "%d" x) 'digit-argument))
         (number-sequence 0 9))


### PR DESCRIPTION
I noticed there wan't a key to set the priority of a heading. This is usually `C-c ,`, and that's why I chose the `,` key.