### PR TITLE
change worf-mode-map for brackets to do insertion when region is active

### DIFF
--- a/worf.el
+++ b/worf.el
@@ -1865,9 +1865,11 @@ calling `self-insert-command'."
 
 (let ((map worf-mode-map))
   ;; ——— Global ———————————————————————————————
-  (define-key map "[" 'worf-backward)
+  (define-key worf-mode-map (kbd "[")
+    `(menu-item "" worf-backward :filter ,(lambda (cmd) (unless (region-active-p) cmd))))
   (define-key map (kbd "M-o") 'worf-back-to-special)
-  (define-key map "]" 'worf-forward)
+  (define-key worf-mode-map (kbd "]")
+    `(menu-item "" worf-forward :filter ,(lambda (cmd) (unless (region-active-p) cmd))))
   (define-key map "=" 'worf-symbolize)
   (define-key map (kbd "M-j") 'worf-meta-newline)
   ;; (define-key map "\C-j" 'hydra-worf-cj/body)


### PR DESCRIPTION
The brackets are used extensively in org mode files. Binding the two to worf command globally makes insertion of bracket very inconvenient. This pull request changes [ and ] 's global binding, and make them work nice with other mode such as simple-paren.