### PR TITLE
Explicitly require hydra package

### DIFF
--- a/worf.el
+++ b/worf.el
@@ -133,6 +133,7 @@
 (require 'ace-link)
 (require 'dired)
 (require 'flyspell)
+(require 'hydra)
 (require 'org)
 (require 'org-agenda)
 (require 'org-attach)


### PR DESCRIPTION
I have noticed that, on some versions of Emacs, requiring `worf` fails with a void-variable error on `hydra-worf-change`. 
This user here abo-abo/pamparam#34 also seems to be getting the same error.

I do not fully understand why, but adding `(require 'hydra)` to the `worf.el` file has completely fixed this issue for me.
Please feel free to just close this PR if you want, as I'm not able to give a good justification of why this works.